### PR TITLE
Fix sending code chunks beginning with a hyphen

### DIFF
--- a/tmux/__init__.py
+++ b/tmux/__init__.py
@@ -14,5 +14,5 @@ def send_to_tmux(cmd, tmux="tmux", bracketed_paste_mode=False):
             cmd = cmd + "\n"
         chunks = [cmd[i:i+n] for i in range(0, len(cmd), n)]
         for chunk in chunks:
-            subprocess.check_call([tmux, 'set-buffer', chunk])
+            subprocess.check_call([tmux, 'set-buffer', '--', chunk])
             subprocess.check_call([tmux, 'paste-buffer', '-d'])


### PR DESCRIPTION
Sending a chunk to tmux used to fail when a chunk started with a hyphen, because the tmux command line utility would interpret the code chunk as an option rather than as data to be stored in a buffer.